### PR TITLE
Update request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://sw.cowtech.it/fastimage",
   "dependencies": {
     "image-size": "~0.5.0",
-    "request": "~2.69.0"
+    "request": "~2.74.0"
   },
   "devDependencies": {
     "chai": "~3.5.0",


### PR DESCRIPTION
There is a vulnerability https://nodesecurity.io/advisories/130, which affects old version of request.
